### PR TITLE
Fix #4: rsync error `Empty source arg specified`

### DIFF
--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -55,7 +55,7 @@ fi
 echo "rsync"
 
 # shellcheck disable=SC2086
-rsync -av $EXCLUDE_OPTIONS "${BASE_DIRECTORY}" "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}" --delete --ignore-missing-args
+rsync -av $EXCLUDE_OPTIONS ${BASE_DIRECTORY} "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}" --delete
 
 # Replace .gitignore with .deployignore recursively.
 if [ -f "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}/.deployignore" ]; then

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -22,6 +22,8 @@ REMOTE_REPO_DIR="${SCRATCH}/remote-repo"
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)
 echo "$COMMIT_MESSAGE" > "${SCRATCH}/commit.message"
 
+echo "Setup SSH key."
+
 # Setup the SSH key.
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh
@@ -46,8 +48,10 @@ if [[ "true" == "${PANTHEON_DEPLOYMENT}" ]]; then
 	EXCLUDE_OPTIONS+="--exclude=.pantheon "
 fi
 
+echo "rsync"
+
 # shellcheck disable=SC2086
-rsync -av $EXCLUDE_OPTIONS "${BASE_DIRECTORY}" "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}" --delete
+rsync -av $EXCLUDE_OPTIONS "${BASE_DIRECTORY}" "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}" --delete --ignore-missing-args
 
 # Replace .gitignore with .deployignore recursively.
 if [ -f "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}/.deployignore" ]; then

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -22,9 +22,6 @@ REMOTE_REPO_DIR="${SCRATCH}/remote-repo"
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)
 echo "$COMMIT_MESSAGE" > "${SCRATCH}/commit.message"
 
-
-echo "Setup SSH key."
-
 # Setup the SSH key.
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh
@@ -32,9 +29,6 @@ chmod 700 ~/.ssh
 # Write the private key to a file, interpret any escaped newlines
 echo -e "${SSH_KEY}" > ~/.ssh/private_key
 chmod 600 ~/.ssh/private_key
-
-
-echo "Clone remote repository"
 
 # Clone remote repository
 git clone --branch "${REMOTE_BRANCH}" "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
@@ -51,8 +45,6 @@ done
 if [[ "true" == "${PANTHEON_DEPLOYMENT}" ]]; then
 	EXCLUDE_OPTIONS+="--exclude=.pantheon "
 fi
-
-echo "rsync"
 
 # shellcheck disable=SC2086
 rsync -av $EXCLUDE_OPTIONS ${BASE_DIRECTORY} "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}" --delete

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -22,6 +22,7 @@ REMOTE_REPO_DIR="${SCRATCH}/remote-repo"
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)
 echo "$COMMIT_MESSAGE" > "${SCRATCH}/commit.message"
 
+
 echo "Setup SSH key."
 
 # Setup the SSH key.
@@ -31,6 +32,9 @@ chmod 700 ~/.ssh
 # Write the private key to a file, interpret any escaped newlines
 echo -e "${SSH_KEY}" > ~/.ssh/private_key
 chmod 600 ~/.ssh/private_key
+
+
+echo "Clone remote repository"
 
 # Clone remote repository
 git clone --branch "${REMOTE_BRANCH}" "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1


### PR DESCRIPTION
Fixes: `Empty source arg specified. rsync error: syntax or usage error (code 1) at main.c(1508) [sender=3.2.7]`

From the rsync NEWS for rsync 3.2.3 (6 Aug 2020) ([link](https://github.com/WayneD/rsync/blob/master/NEWS.md
)):

> A completely empty source arg is now a fatal error. This doesn't change the handling of implied dot-dir args such as "localhost:" and such.


From https://git.taediumvitae.de/backup-sdcard/commit/908266ce302fb44a060d99125975ca8f8550426d.html