### PR TITLE
Issue-6: Don't Sync mu-plugins/pantheon-mu-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `Deploy to Remote Repository Action` will be documented in this file.
 
+## 2.0.0 - 2024-05-10
+
+- Potential **breaking change**: extends [Pantheon Mode](/README.md#pantheon-mode) to automatically add `mu-plugins/pantheon-mu-plugin` to the [exclude list](/README.md#exclude_list) to prevent common deployment errors related to this directory.
+
 ## 1.1.0 - 2023-07-12
 
 - Adds support for copying the `private` folder to the root in Pantheon deploys.

--- a/README.md
+++ b/README.md
@@ -51,11 +51,15 @@ version control (such as built assets and Composer dependencies). The
 
 ### Pantheon Mode
 
-Passing `pantheon: 'true'` to the action will enable "Pantheon" mode. This will
-allow the action to copy the `.pantheon/pantheon.yml` file (if it exists) to the
-root of the repository as `pantheon.yml`. This is useful for projects that are
-rooted at `wp-content` but still want to version control their Pantheon
-configuration.
+Passing `pantheon: 'true'` to the action will enable "Pantheon" mode. This mode
+provides the following features:
+
+- Copies the `.pantheon/pantheon.yml` file (if it exists) to the root of the
+  repository as `pantheon.yml`. This is useful for projects that are rooted at
+  `wp-content` but still want to version control their Pantheon configuration.
+- Copies the `.pantheon/private` directory (if it exists) to the root of the
+  repository as `private`.
+- Automatically adds `.pantheon` and `mu-plugins/pantheon-mu-plugin` to the [exclude list](#exclude_list) to prevent common deployment errors related to these directories.
 
 ## Inputs
 
@@ -106,9 +110,7 @@ configuration.
 
 ### `pantheon`
 
-- Determine if this is a deployment for a Pantheon repository. Supports
-  migrating `.pantheon/pantheon.yml` to `pantheon.yml` and
-  `.pantheon/private` to `private` in the root of the repository.
+- Determine if this is a deployment for a Pantheon repository. See [Pantheon Mode](#pantheon-mode) for more details.
 - Accepts a string. (e.g. `true` or `false`)
 - Defaults to `false`.
 

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -43,7 +43,7 @@ for EXCLUDE in "${EXCLUDES[@]}"; do
 	EXCLUDE_OPTIONS+="--exclude=${EXCLUDE} "
 done
 if [[ "true" == "${PANTHEON_DEPLOYMENT}" ]]; then
-	EXCLUDE_OPTIONS+="--exclude=.pantheon "
+	EXCLUDE_OPTIONS+="--exclude=.pantheon --exclude=mu-plugins/pantheon-mu-plugin "
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
### Summary

Fixes #6

This pull request aims to address the issue described in [#6](https://github.com/alleyinteractive/action-deploy-to-remote-repository/issues/6), where syncing `mu-plugins/pantheon-mu-plugin` during Pantheon upstream updates causes errors due to merge conflicts. The proposed solution is to automatically exclude `pantheon-mu-plugin` from the sync process when the `pantheon` boolean flag is set to true, simplifying the deployment process for users targeting Pantheon environments.

### Changes

- Automatically add `pantheon-mu-plugin` to the exclude list during rsync if the `pantheon` flag is true.
- Update the documentation to reflect this automatic behavior.

### Rationale

As discussed in the issue comments, requiring all users to manually add `pantheon-mu-plugin` to the exclude list could be error-prone and inconvenient. By making this exclusion automatic for users deploying to Pantheon, we streamline the process and prevent common deployment errors related to `pantheon-mu-plugin`.

### Testing

1. Set the `pantheon` flag to true in a project's deployment configuration.
2. Deploy changes to a Pantheon environment.
3. Apply upstream updates, such as a WordPress update, and verify that the process completes successfully without errors related to `mu-plugins/pantheon-mu-plugin`.

### Additional Notes

None.