### PR TITLE
v3 Release Prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ provides the following features:
 - Defaults to the same branch name in the remote repo as the current running
   action.
 
+### `remote_branch_is_orphan`
+
+- Whether to use the `--orphan` flag when creating the remote branch.
+- Accepts a string. (e.g. `true` or `false`)
+- Defaults to `false`.
+
 ### `base_directory`
 
 - Specify the base directory to sync from.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The action supports recursively replacing all `.gitignore` files in your project
 with a root-level `.deployignore` file if one is found. This is useful for
 excluding files from the deployment that would have previously been ignored by
 version control (such as built assets and Composer dependencies). The
-`.deployignore` syntax is the same as a normal `.gitignore` file.
+`.deployignore` syntax is the same as a normal `.gitignore` file. To skip invoking
+this behavior, use the `deployignore: 'false'` input.
 
 ### Pantheon Mode
 
@@ -108,6 +109,12 @@ provides the following features:
 - Specify a comma-separated list of files and directories to exclude from sync.
 - Accepts a string. (e.g. `.git, .gitmodules, .github`)
 - Defaults to `.git, .gitmodules, .github`.
+
+### `deployignore`
+
+- Whether to replace `.gitignore` with `.deployignore` if the files exist.
+- Accepts a string. (e.g. `true` or `false`)
+- Defaults to `true`.
 
 ### `ssh-key`
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   remote_branch:
     description: 'Remote branch to clone and push'
     required: false
+  remote_branch_is_orphan:
+    description: 'Whether to use the --orphan flag when creating the remote branch'
+    required: false
   base_directory:
     description: 'Base directory for rsync'
     required: false
@@ -44,6 +47,7 @@ runs:
         GIT_SSH_COMMAND: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/private_key
         PANTHEON_DEPLOYMENT: ${{ inputs.pantheon }}
         REMOTE_BRANCH: ${{ inputs.remote_branch != '' && inputs.remote_branch || github.ref_name }}
+        REMOTE_BRANCH_ORPHAN_FLAG: ${{ inputs.remote_branch_is_orphan == 'true' && '--orphan' || '' }}
         REMOTE_REPO_DIR: /tmp/remote_repo
         REMOTE_REPO: ${{ inputs.remote_repo }}
         SSH_KEY: ${{ inputs.ssh-key }}

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,15 @@ inputs:
   remote_branch_is_orphan:
     description: 'Whether to use the --orphan flag when creating the remote branch'
     required: false
+    default: 'false'
   base_directory:
     description: 'Base directory for rsync'
     required: false
     default: '.'
+  deployignore:
+    description: 'Whether to replace .gitignore with .deployignore'
+    required: false
+    default: 'true'
   destination_directory:
     description: 'Destination directory for rsync in remote repository'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,7 @@ runs:
     - id: deploy-to-remote-repository
       env:
         BASE_DIRECTORY: ${{ inputs.base_directory }}
+        DEPLOYIGNORE: ${{ inputs.deployignore }}
         DESTINATION_DIRECTORY: ${{ inputs.destination_directory }}
         EXCLUDE_LIST: ${{ inputs.exclude_list }}
         GIT_SSH_COMMAND: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/private_key

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -30,8 +30,14 @@ chmod 700 ~/.ssh
 echo -e "${SSH_KEY}" > ~/.ssh/private_key
 chmod 600 ~/.ssh/private_key
 
-# Clone remote repository
-git clone --branch "${REMOTE_BRANCH}" "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
+# Clone remote repository; create deploy branch if it does not exist
+if [[ 0 = $(git ls-remote --heads "${REMOTE_REPO}" "${REMOTE_BRANCH}" | wc -l) ]]; then
+	git clone "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
+	cd "${REMOTE_REPO_DIR}" || exit 1
+	git checkout --quiet "${REMOTE_BRANCH_ORPHAN_FLAG}" "${DEPLOY_BRANCH}"
+else
+	git clone --branch "${REMOTE_BRANCH}" "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
+fi
 
 # Rsync current repository to remote repository. Split the exclude list into an
 # array by splitting on commas.

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -34,7 +34,7 @@ chmod 600 ~/.ssh/private_key
 if [[ 0 = $(git ls-remote --heads "${REMOTE_REPO}" "${REMOTE_BRANCH}" | wc -l) ]]; then
 	git clone "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
 	cd "${REMOTE_REPO_DIR}" || exit 1
-	git checkout --quiet "${REMOTE_BRANCH_ORPHAN_FLAG}" "${DEPLOY_BRANCH}"
+	git checkout --quiet "${REMOTE_BRANCH_ORPHAN_FLAG}" "${REMOTE_BRANCH}"
 else
 	git clone --branch "${REMOTE_BRANCH}" "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
 fi

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -35,7 +35,6 @@ if [[ 0 = $(git ls-remote --heads "${REMOTE_REPO}" "${REMOTE_BRANCH}" | wc -l) ]
 	git clone "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
 	cd "${REMOTE_REPO_DIR}" || exit 1
 	git checkout --quiet "${REMOTE_BRANCH_ORPHAN_FLAG}" "${REMOTE_BRANCH}"
-	git push --set-upstream origin "${REMOTE_BRANCH}"
 else
 	git clone --branch "${REMOTE_BRANCH}" "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
 fi
@@ -96,4 +95,4 @@ git commit --allow-empty -a --file="${SCRATCH}/commit.message"
 
 # Push the new branch to the remote repository
 echo "Pushing to ${REMOTE_REPO}@${REMOTE_BRANCH}"
-git push -u origin
+git push -u origin "${REMOTE_BRANCH}"

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -35,6 +35,7 @@ if [[ 0 = $(git ls-remote --heads "${REMOTE_REPO}" "${REMOTE_BRANCH}" | wc -l) ]
 	git clone "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
 	cd "${REMOTE_REPO_DIR}" || exit 1
 	git checkout --quiet "${REMOTE_BRANCH_ORPHAN_FLAG}" "${REMOTE_BRANCH}"
+	git push --set-upstream origin "${REMOTE_BRANCH}"
 else
 	git clone --branch "${REMOTE_BRANCH}" "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
 fi

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -33,10 +33,10 @@ chmod 600 ~/.ssh/private_key
 # Clone remote repository; create deploy branch if it does not exist
 if [[ 0 = $(git ls-remote --heads "${REMOTE_REPO}" "${REMOTE_BRANCH}" | wc -l) ]]; then
 	git clone "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
-	BASE_DIRECTORY=$(pwd)
+	CURRENT_DIRECTORY=$(pwd)
 	cd "${REMOTE_REPO_DIR}" || exit 1
 	git checkout --quiet "${REMOTE_BRANCH_ORPHAN_FLAG}" "${REMOTE_BRANCH}"
-	cd "${BASE_DIRECTORY}" || exit 1
+	cd "${CURRENT_DIRECTORY}" || exit 1
 else
 	git clone --branch "${REMOTE_BRANCH}" "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
 fi

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -58,7 +58,7 @@ fi
 rsync -av $EXCLUDE_OPTIONS "${BASE_DIRECTORY}" "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}" --delete
 
 # Replace .gitignore with .deployignore recursively.
-if [[ "false" != "${DEPLOYIGNORE}" && -f "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}/.deployignore" ]]; then
+if [[ "true" == "${DEPLOYIGNORE}" && -f "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}/.deployignore" ]]; then
 	echo "Replacing .gitignore with .deployignore"
 
 	find "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}" -type f -name '.gitignore' | while read -r GITIGNORE_FILE; do
@@ -86,7 +86,7 @@ fi
 cd "${REMOTE_REPO_DIR}" || exit 1
 
 # If we are processing a deployignore file, also remove any newly ignored files from being tracked by git
-if [[ "false" != "${DEPLOYIGNORE}" ]]; then
+if [[ "true" == "${DEPLOYIGNORE}" ]]; then
 	git ls-files -ciz --exclude-standard | xargs -0 git rm --cached
 fi
 

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -83,14 +83,19 @@ if [[ "true" == "${PANTHEON_DEPLOYMENT}" ]]; then
 	fi
 fi
 
-# Commit and push changes to remote repository
 cd "${REMOTE_REPO_DIR}" || exit 1
+
+# If we are processing a deployignore file, remove any files that are tracked by git but should be ignored
+if [[ "false" != "${DEPLOYIGNORE}" ]]; then
+	git ls-files -i --exclude-standard -z | xargs -0 rm -rf
+fi
 
 # Set git user.name to include repository name
 REPO_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F '/' '{print $2}')
 git config user.name "${REPO_NAME} GitHub Action"
 git config user.email "action@github.com"
 
+# Commit changes
 git add -A
 git status
 git commit --allow-empty -a --file="${SCRATCH}/commit.message"

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -87,7 +87,7 @@ cd "${REMOTE_REPO_DIR}" || exit 1
 
 # If we are processing a deployignore file, also remove any newly ignored files from being tracked by git
 if [[ "true" == "${DEPLOYIGNORE}" ]]; then
-	git ls-files -ciz --exclude-standard | xargs -0 git rm --cached
+	git ls-files -ciz --exclude-standard | xargs -0 git rm -f --cached
 fi
 
 # Set git user.name to include repository name

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -85,9 +85,9 @@ fi
 
 cd "${REMOTE_REPO_DIR}" || exit 1
 
-# If we are processing a deployignore file, remove any files that are tracked by git but should be ignored
+# If we are processing a deployignore file, also remove any newly ignored files from being tracked by git
 if [[ "false" != "${DEPLOYIGNORE}" ]]; then
-	git ls-files -i --exclude-standard -z | xargs -0 rm -rf
+	git ls-files -ciz --exclude-standard | xargs -0 git rm --cached
 fi
 
 # Set git user.name to include repository name

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -87,7 +87,10 @@ cd "${REMOTE_REPO_DIR}" || exit 1
 
 # If we are processing a deployignore file, also remove any newly ignored files from being tracked by git
 if [[ "true" == "${DEPLOYIGNORE}" ]]; then
-	git ls-files -ciz --exclude-standard | xargs -0 git rm -f --cached
+	IGNORED_FILES=$(git ls-files -ci --exclude-standard)
+	if [[ -n "$IGNORED_FILES" ]]; then
+		git ls-files -ciz --exclude-standard | xargs -0 git rm -f --cached
+	fi
 fi
 
 # Set git user.name to include repository name

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -33,8 +33,10 @@ chmod 600 ~/.ssh/private_key
 # Clone remote repository; create deploy branch if it does not exist
 if [[ 0 = $(git ls-remote --heads "${REMOTE_REPO}" "${REMOTE_BRANCH}" | wc -l) ]]; then
 	git clone "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
+	BASE_DIRECTORY=$(pwd)
 	cd "${REMOTE_REPO_DIR}" || exit 1
 	git checkout --quiet "${REMOTE_BRANCH_ORPHAN_FLAG}" "${REMOTE_BRANCH}"
+	cd "${BASE_DIRECTORY}" || exit 1
 else
 	git clone --branch "${REMOTE_BRANCH}" "${REMOTE_REPO}" "${REMOTE_REPO_DIR}" --depth 1
 fi

--- a/deploy-to-remote-repository.sh
+++ b/deploy-to-remote-repository.sh
@@ -58,7 +58,7 @@ fi
 rsync -av $EXCLUDE_OPTIONS "${BASE_DIRECTORY}" "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}" --delete
 
 # Replace .gitignore with .deployignore recursively.
-if [ -f "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}/.deployignore" ]; then
+if [[ "false" != "${DEPLOYIGNORE}" && -f "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}/.deployignore" ]]; then
 	echo "Replacing .gitignore with .deployignore"
 
 	find "${REMOTE_REPO_DIR}/${DESTINATION_DIRECTORY}" -type f -name '.gitignore' | while read -r GITIGNORE_FILE; do


### PR DESCRIPTION
This PR introduces four new features that will comprise the core of a v3 release of this action:
1. The ability to create the target branch if it does not already exist.
2. The ability to specify that the target branch should be created using the `--orphan` flag.
3. The ability to skip the automatic replacement of `.gitignore` with `.deployignore`, if the file is present in the repo.
4. Automatic removal of any tracked files in the working tree that are newly ignored after replacing `.gitignore` with the contents of `.deployignore`.

Fixes #15 
Fixes #17 
Fixes #18 
Fixes #19 